### PR TITLE
Restore SHA result card display

### DIFF
--- a/KriptografiFinalProje/Views/SHA/Index.cshtml
+++ b/KriptografiFinalProje/Views/SHA/Index.cshtml
@@ -46,7 +46,7 @@
     </div>
 
     <!-- Özet Sonucu -->
-    <div class="cyber-card mt-4">
+    <div class="cyber-card mt-4 result-card">
         <h3 class="mb-4">
             <i class="fas fa-hashtag me-2"></i>
             SHA-256 Özeti

--- a/KriptografiFinalProje/wwwroot/css/site.css
+++ b/KriptografiFinalProje/wwwroot/css/site.css
@@ -302,6 +302,10 @@ input[type="file"]::-webkit-file-upload-button:hover {
     animation-delay: 0.6s;
 }
 
+.result-card {
+    animation: fadeInUp 0.8s ease-out forwards;
+    animation-delay: 0.9s;
+}
 /* Sonuç Kutusu Pozisyonu */
 .result-container {
     position: relative;


### PR DESCRIPTION
## Summary
- show SHA-256 result card by adding animation class
- ensure SHA page uses the new `result-card` style

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847e4badd548329b82ab100e49142ea